### PR TITLE
fix: Delegate should not be set when new webview is opened as a new t…

### DIFF
--- a/Sources/TWS/Sources/Models/TWSViewState.swift
+++ b/Sources/TWS/Sources/Models/TWSViewState.swift
@@ -60,9 +60,6 @@ public final class TWSViewState {
     /// URL that is currently displayed in TWSView
     public var currentUrl: URL? = nil
     
-    /// URL that will be presented with a sheet
-    public var presentedUrl: URL?
-    
     /// Initialiezes a class that ``TWSView`` uses to store information in
     /// - Parameter title: default title of the page
     /// - Parameter loadingState: the initial state for the loading state

--- a/Sources/TWS/Sources/Views/WebView/TWSView+WebView.swift
+++ b/Sources/TWS/Sources/Views/WebView/TWSView+WebView.swift
@@ -124,7 +124,7 @@ struct WebView: UIViewRepresentable {
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
         
-        if navigator.delegate == nil {
+        if state.presentedUrl == nil {
             navigator.delegate = context.coordinator
         }
 

--- a/Sources/TWS/Sources/Views/WebView/TWSView+WebView.swift
+++ b/Sources/TWS/Sources/Views/WebView/TWSView+WebView.swift
@@ -26,6 +26,8 @@ struct WebView: UIViewRepresentable {
     @Binding var canGoBack: Bool
     @Binding var canGoForward: Bool
     @Bindable var state: TWSViewState
+    @Binding var presentedUrl: URL?
+    @Binding var parentSnippet: TWSSnippet?
 
     var id: String { snippet.id }
     var targetURL: URL { snippet.target }
@@ -60,7 +62,9 @@ struct WebView: UIViewRepresentable {
         canGoBack: Binding<Bool>,
         canGoForward: Binding<Bool>,
         downloadCompleted: ((TWSDownloadState) -> Void)?,
-        state: Bindable<TWSViewState>
+        state: Bindable<TWSViewState>,
+        presentedUrl: Binding<URL?>,
+        parentSnippet: Binding<TWSSnippet?>
     ) {
         self.snippet = snippet
         self.preloadedResources = preloadedResources
@@ -80,6 +84,8 @@ struct WebView: UIViewRepresentable {
         self._canGoForward = canGoForward
         self.downloadCompleted = downloadCompleted
         self._state = state
+        self._presentedUrl = presentedUrl
+        self._parentSnippet = parentSnippet
     }
 
     func makeUIView(context: Context) -> WKWebView {
@@ -124,7 +130,7 @@ struct WebView: UIViewRepresentable {
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
         
-        if state.presentedUrl == nil {
+        if parentSnippet == nil {
             navigator.delegate = context.coordinator
         }
 
@@ -165,7 +171,7 @@ struct WebView: UIViewRepresentable {
             navigationProvider: navigationProvider,
             downloadCompleted: downloadCompleted,
             interceptor: interceptor,
-            presentedUrl: $state.presentedUrl
+            presentedUrl: $presentedUrl
         )
     }
 


### PR DESCRIPTION
…ab, otherwise it should be set, so it does not get nulled out on redraws

- This was causing custom navigation to not work, if socket update was received, or if for any other reason TWSView got redrawn. Navigator did not get nulled out, however it held on to a reference of the web views coordinator that has already been replaced